### PR TITLE
Fix a build failure with Carthage build by removing "Run" and "Analyz…

### DIFF
--- a/Observable-Swift.xcodeproj/xcshareddata/xcschemes/Observable-iOS.xcscheme
+++ b/Observable-Swift.xcodeproj/xcshareddata/xcschemes/Observable-iOS.xcscheme
@@ -22,10 +22,10 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "6592C3051957532100BA8CB7"


### PR DESCRIPTION
Fix a build failure with Carthage build by removing "Run" and "Analyze" build actions for the iOS unit test target